### PR TITLE
it should be the mutex.decrenment() other than mutex.unlock(). The guide...

### DIFF
--- a/src/threads/part2/SafeGuard.cpp
+++ b/src/threads/part2/SafeGuard.cpp
@@ -32,7 +32,8 @@ struct ConcurrentSafeCounter {
 
     void decrement(){
         std::lock_guard<std::mutex> guar(mutex);
-        mutex.unlock();
+        counter.decrement();
+        //mutex.unlock();
     }
 };
 


### PR DESCRIPTION
... takes care about the mutex lock/unlock.
