### PR TITLE
Bug fix in AtomicCounter.cpp

### DIFF
--- a/src/threads/part4/AtomicCounter.cpp
+++ b/src/threads/part4/AtomicCounter.cpp
@@ -4,22 +4,15 @@
 #include <vector>
 
 struct AtomicCounter {
-    bool flag = false;
     std::atomic<int> value;
 
+    AtomicCounter() { value = 0; }
+
     void increment(){
-       if(!flag) {
-         value = 0;
-         flag = true;
-       }
         ++value;
     }
 
     void decrement(){
-        if(!flag) {
-	  value = 0;
-	  flag = true;
-	}
         --value;
     }
 


### PR DESCRIPTION
Since default initialization of std::atomic<int> in a class object is poor supported in g++4.7/4.8, use flag to do lazy initialization.
